### PR TITLE
Better support for Cherry Picker mod by removing non-drugs from policies when fixing them up.

### DIFF
--- a/Languages/English/Keyed/DrugPolicyFix_LangData.xml
+++ b/Languages/English/Keyed/DrugPolicyFix_LangData.xml
@@ -3,5 +3,6 @@
   <!-- Content -->
   <DrugPolicyFix.DoneNothing>Drug Policy Fix: Has checked all policies and found no new additions needed.</DrugPolicyFix.DoneNothing>
   <DrugPolicyFix.Feedback>Drug Policy Fix: Number of policies effected: {0}, with {1} drug references applied to all policies.</DrugPolicyFix.Feedback>
+  <DrugPolicyFix.Removed>Drug Policy Fix: Number of policies cleaned up: {0}, with {1} non-drugs removed from all policies.</DrugPolicyFix.Removed>
   <DrugPolicyFix.Sorted>Drug Policy Fix: Sorted {0} drug policies.</DrugPolicyFix.Sorted>
 </LanguageData>

--- a/Source/DrugPolicyFix/DrugPolicyFix.cs
+++ b/Source/DrugPolicyFix/DrugPolicyFix.cs
@@ -47,12 +47,13 @@ namespace DrugPolicyFix
                             }
                         }
                     }
-                    defsRemovedCount = existingDrugPolicyEntries.Count - filteredDrugPolicyEntries.Count;
-                    if (defsRemovedCount > 0)
+
+                    if (existingDrugPolicyEntries.Count > filteredDrugPolicyEntries.Count)
                     {
+                        defsRemovedCount = existingDrugPolicyEntries.Count - filteredDrugPolicyEntries.Count;
                         policiesRemovedFromCount++;
+                        NonPublicFields.DrugPolicyEntryList(drugPolicy) = filteredDrugPolicyEntries;
                     }
-                    NonPublicFields.DrugPolicyEntryList(drugPolicy) = filteredDrugPolicyEntries;
 
                     // Find new drugs that aren't already in the policy to add
                     var drugDefsToAdd = new List<ThingDef>();


### PR DESCRIPTION
The intention of this change is to support using mods like Cherry Picker to disable unwanted drugs without having them mess up all of your policies. I don't think it should be needed for simply uninstalling a mod since that would delete the ThingDefs entirely and based on my experience I think the game already handles that.

### Changes

- loop through all defs to find drugs once only instead of once per
policy
- remove non-drugs from the policy using the same logic that is used to
find new drugs in the global def list
- log out any drug removals
- cleaned up the IsDrug function to remove unused `out` parameter

### Known issues

- No german translation as I don't speak german
- ~~Not tested yet~~, I'm pretty new to Rimworld modding and C# development although I have a lot of general programming experience. I tried to stick to the existing code style even when there were weird behaviors that didn't make a lot of sense to me (like checking that the count of a list was greater than 0 before using `foreach` on it...?) ~~Once I figure out how to compile and run mods on Linux I can let you know how it worked~~, but proofreading or help with testing would be appreciated :)
  - edit: I managed to get it compiled and running, found a bug in the logging but other than that it seems to be working :tada: 